### PR TITLE
Remove padding

### DIFF
--- a/css/hacks.css
+++ b/css/hacks.css
@@ -201,8 +201,6 @@ footer{
 .fa-instagram {
   background: #546e7a;
   color: white;
-  padding-left: 0px;
-  padding-right: 40px;
 
 }
 


### PR DESCRIPTION
For some reason this padding was on the instagram icon causing it to be off-center. Probably leftover from prev. website with more than one icon.